### PR TITLE
Add takeWhile transformation

### DIFF
--- a/features.md
+++ b/features.md
@@ -47,7 +47,7 @@
   - [ ] reduce
   - [ ] take
   - [ ] drop
-  - [ ] takeWhile
+  - [X] takeWhile
   - [ ] dropWhile
 - [ ] Python-like list comprehensions, e.g. `[x*5 for x in xs]`
 

--- a/integtests/basictakewhile.cigg
+++ b/integtests/basictakewhile.cigg
@@ -1,0 +1,2 @@
+// EXPECT [1, 2]
+print(takeWhile ((x) => x < 3) [1..5]);

--- a/integtests/chainedtakewhile.cigg
+++ b/integtests/chainedtakewhile.cigg
@@ -1,0 +1,3 @@
+// EXPECT [5, 10, 15]
+let xs = takeWhile ((x) => x < 20) map ((x) => x*5) [1..10];
+print(xs);

--- a/integtests/takewhilenoparen.cigg
+++ b/integtests/takewhilenoparen.cigg
@@ -1,0 +1,5 @@
+// EXPECT [1, 2, 3, 4]
+fn lt5(x) {
+  return x < 5;
+}
+print(takeWhile lt5 [1..10]);

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -472,7 +472,7 @@ impl Compiler {
         for (i, tf) in TRANSFORMATION_FNS.iter().enumerate() {
             if self.peek(1).lexeme == tf.name {
                 match tf.name {
-                    "map" | "filter" => {
+                    "map" | "filter" | "takeWhile" => {
                         if self.peek(0).token_type == TokenType::LeftParen {
                             self.consume(TokenType::LeftParen, "Expected '(' after transformation");
                             self.expression();

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -225,6 +225,7 @@ impl Scanner {
             "filter" => Token::new(TokenType::Transformation, lexeme, self.line),
             "words" => Token::new(TokenType::Transformation, lexeme, self.line),
             "sort" => Token::new(TokenType::Transformation, lexeme, self.line),
+            "takeWhile" => Token::new(TokenType::Transformation, lexeme, self.line),
             _ => Token::new(TokenType::Identifier, lexeme, self.line),
         }
     }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -359,6 +359,30 @@ fn filter(vm: &mut VM) {
     }
 }
 
+fn take_while(vm: &mut VM) {
+    let array = vm.pop();
+    let function = vm.pop();
+
+    let mut result = Vec::new();
+    match array {
+        Value::Array(a) => {
+            let a = a.borrow();
+            for item in a.iter() {
+                let keep = apply_function(vm, function.clone(), item.clone()).is_truthy();
+                if keep {
+                    result.push(item.clone());
+                } else {
+                    break;
+                }
+            }
+            vm.push(Value::Array(Rc::new(RefCell::new(result))));
+        }
+        _ => {
+            vm.runtime_error("Expected array for takeWhile");
+        }
+    }
+}
+
 fn words_delimiter(vm: &mut VM) {
     let string = vm.pop();
     let delimiter = vm.pop();
@@ -426,7 +450,7 @@ fn sort(vm: &mut VM) {
     }
 }
 
-pub const TRANSFORMATION_FNS: [TransformationFunction; 5] = [
+pub const TRANSFORMATION_FNS: [TransformationFunction; 6] = [
     TransformationFunction {
         name: "map",
         function: map,
@@ -447,6 +471,10 @@ pub const TRANSFORMATION_FNS: [TransformationFunction; 5] = [
     TransformationFunction {
         name: "sort",
         function: sort,
+    },
+    TransformationFunction {
+        name: "takeWhile",
+        function: take_while,
     },
 ];
 


### PR DESCRIPTION
## Summary
- implement `takeWhile` transformation function in the VM
- recognise `takeWhile` token in the scanner
- compile `takeWhile` in the same way as `map` and `filter`
- register the new transformation in the transformation list
- mark feature complete in docs
- add integration tests for takeWhile

## Testing
- `cargo build`
- `python3 integration_tests.py`
- `cargo build --features debug_trace_execution,debug_disassemble`
- `python3 integration_tests.py --debugintegration`
