### PR TITLE
Add support for add and subtract to sets/hashmaps

### DIFF
--- a/features.md
+++ b/features.md
@@ -16,6 +16,7 @@
 - [X] functions (with return values and params)
 - [X] Arrays
 - [X] Hashmaps / Sets
+  - [X] Support add and subtract
 - [X] Python-like 'in' operator (arrays, strings, hashmaps)
 - [X] I/O with outside world, e.g. read file/stdin
 

--- a/integtests/REsubtractstrings.cigg
+++ b/integtests/REsubtractstrings.cigg
@@ -1,3 +1,3 @@
-// EXPECT ERR Expected numbers to sub operation at [line 2] in script\nRuntime error
+// EXPECT ERR Expected numbers or two hashmaps for sub operation, but got: String(RefCell { value: ['s', 'd', 'l', 'k', 'f', 'j', 's', 'd', 'f'] }) and String(RefCell { value: ['a'] }) at [line 2] in script\nRuntime error
 "sdlkfjsdf" - "a";
 

--- a/integtests/set_add_subtract.cigg
+++ b/integtests/set_add_subtract.cigg
@@ -1,0 +1,17 @@
+// EXPECT [1, 2, 3, 4, 5]\n[1, 2, 3]
+fn get_sorted(set) {
+  let result = [];
+  for x in set {
+    result :: x;
+  }
+  return result;
+}
+let one = {1, 2, 3};
+let two = {4, 5};
+
+let three = one + two;
+print(get_sorted(three));
+
+let four = three - two;
+print(get_sorted(four));
+

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -787,7 +787,7 @@ impl VM {
                 }
                 if !a.is_number() || !b.is_number() {
                     self.runtime_error(&format!(
-                        "Expected numbers, a string, two arrays or two hashmaps for add operation, but got: {:?} and {:?}",
+                        "Expected numbers, a string, arrays, or hashmaps for add operation, but got: {:?} and {:?}",
                         a, b
                     ));
                     return;

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -193,6 +193,10 @@ impl Value {
         matches!(self, Value::Array(_))
     }
 
+    pub fn is_hashmap(&self) -> bool {
+        matches!(self, Value::HashMap(_))
+    }
+
     pub fn is_truthy(&self) -> bool {
         match self {
             Value::Bool(b) => *b,
@@ -763,9 +767,27 @@ impl VM {
                     self.push(Value::Array(Rc::new(RefCell::new(result))));
                     return;
                 }
+                if a.is_hashmap() && b.is_hashmap() {
+                    let a = match a {
+                        Value::HashMap(a) => a,
+                        _ => unreachable!(),
+                    };
+                    let b = match b {
+                        Value::HashMap(b) => b,
+                        _ => unreachable!(),
+                    };
+                    // TODO: This is sketchy since we can mutate the thing used as a key. So we can
+                    // have an issue where hash lookups start failling because we inserted
+                    // something as a key and then mutated it. Leaving it as is for now since
+                    // changing the entire Value type is complicated
+                    let mut result = a.borrow().0.clone();
+                    result.extend(b.borrow().0.clone());
+                    self.push(Value::HashMap(Rc::new(RefCell::new(CiggHashMap(result)))));
+                    return;
+                }
                 if !a.is_number() || !b.is_number() {
                     self.runtime_error(&format!(
-                        "Expected numbers, a string, or two arrays for add operation, but got: {:?} and {:?}",
+                        "Expected numbers, a string, two arrays or two hashmaps for add operation, but got: {:?} and {:?}",
                         a, b
                     ));
                     return;
@@ -773,8 +795,31 @@ impl VM {
                 self.push(Value::Number(a.as_number() + b.as_number()));
             }
             OpCode::Sub => {
+                if a.is_hashmap() && b.is_hashmap() {
+                    let a = match a {
+                        Value::HashMap(a) => a,
+                        _ => unreachable!(),
+                    };
+                    let b = match b {
+                        Value::HashMap(b) => b,
+                        _ => unreachable!(),
+                    };
+                    // TODO: This is sketchy since we can mutate the thing used as a key. So we can
+                    // have an issue where hash lookups start failling because we inserted
+                    // something as a key and then mutated it. Leaving it as is for now since
+                    // changing the entire Value type is complicated
+                    let mut result = a.borrow().0.clone();
+                    for key in b.borrow().0.keys() {
+                        result.remove(key);
+                    }
+                    self.push(Value::HashMap(Rc::new(RefCell::new(CiggHashMap(result)))));
+                    return;
+                }
                 if !a.is_number() || !b.is_number() {
-                    self.runtime_error("Expected numbers to sub operation");
+                    self.runtime_error(&format!(
+                        "Expected numbers or two hashmaps for sub operation, but got: {:?} and {:?}",
+                        a, b
+                    ));
                     return;
                 }
                 self.push(Value::Number(a.as_number() - b.as_number()));


### PR DESCRIPTION
Adds support for add and subtract for the set/hashmaps. Implementation is a bit sketchy since Values are mutable but are still used as keys in hashmaps... Added TODO's appropriately.